### PR TITLE
use SwiftUI instead of SwiftUICore

### DIFF
--- a/Sources/Aizome/StringStyle/BasicStringStyle.swift
+++ b/Sources/Aizome/StringStyle/BasicStringStyle.swift
@@ -1,5 +1,5 @@
 import Foundation
-import SwiftUICore
+import SwiftUI
 
 /// A simple implementation of `StringStyle` using basic font, color, and underline options.
 public struct BasicStringStyle: AizomeStringStyle {


### PR DESCRIPTION
`import SwiftUICore` 指定だと、Xcode 26でビルドができない
`import SwiftUI` 指定に変更する。