### PR TITLE
取り消し線をBasicStringStyleに追加

### DIFF
--- a/Example/AizomeExample/ContentView.swift
+++ b/Example/AizomeExample/ContentView.swift
@@ -44,6 +44,13 @@ struct ContentView: View {
             ]))
                 .font(.body)
                 .multilineTextAlignment(.leading)
+            
+            Text(styledString(
+                "<strikethrough>Deleted text.</strikethrough>",
+                styles: [
+                    "strikethrough": BasicStringStyle(strikethrough: true)
+                ]
+            ))
         }
         .padding()
     }

--- a/Example/AizomeExample/ContentView.swift
+++ b/Example/AizomeExample/ContentView.swift
@@ -46,7 +46,7 @@ struct ContentView: View {
                 .multilineTextAlignment(.leading)
             
             Text(styledString(
-                "<strikethrough>Deleted text.</strikethrough>",
+                "<strikethrough>Cancelled text.</strikethrough>",
                 styles: [
                     "strikethrough": BasicStringStyle(strikethrough: true)
                 ]

--- a/Sources/Aizome/StringStyle/BasicStringStyle.swift
+++ b/Sources/Aizome/StringStyle/BasicStringStyle.swift
@@ -6,11 +6,13 @@ public struct BasicStringStyle: AizomeStringStyle {
     var font: Font? = nil
     var color: Color? = nil
     var underline: Bool = false
+    var strikethrough: Bool = false
     
-    public init(font: Font? = nil, color: Color? = nil, underline: Bool = false) {
+    public init(font: Font? = nil, color: Color? = nil, underline: Bool = false, strikethrough: Bool = false) {
         self.font = font
         self.color = color
         self.underline = underline
+        self.strikethrough = strikethrough
     }
     
     public func apply(to attributed: inout AttributedString, range: Range<AttributedString.Index>) {
@@ -22,6 +24,9 @@ public struct BasicStringStyle: AizomeStringStyle {
         }
         if underline {
             attributed[range].underlineStyle = .single
+        }
+        if strikethrough {
+            attributed[range].strikethroughStyle = .single
         }
     }
 }

--- a/Sources/Aizome/StringStyle/BasicStringStyle.swift
+++ b/Sources/Aizome/StringStyle/BasicStringStyle.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-/// A simple implementation of `StringStyle` using basic font, color, and underline options.
+/// A simple implementation of `StringStyle` using basic font, color, underline, and strikethrough options.
 public struct BasicStringStyle: AizomeStringStyle {
     var font: Font? = nil
     var color: Color? = nil


### PR DESCRIPTION
https://github.com/iseebi/aizome-swiftui/issues/8
上記で作成したIssueの対応PRになりますmm

## 修正内容
- BasicStringStyleに下線同様に取り消し線のフラグ引数を追加
- Exampleに取り消し線のサンプルコードを追加

## エビデンス
<img width="700" src="https://github.com/user-attachments/assets/b781ecd5-e9bd-48bf-ae63-4b26d5a07383" />

