### PR TITLE
add AizomeUIKit

### DIFF
--- a/Example/AizomeExample.xcodeproj/project.pbxproj
+++ b/Example/AizomeExample.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		82CF86EB2DA7908D00ABC3F4 /* Aizome in Frameworks */ = {isa = PBXBuildFile; productRef = 82CF86EA2DA7908D00ABC3F4 /* Aizome */; };
+		82CF86EC2DA7908D00ABC3F4 /* AizomeUIKit in Frameworks */ = {isa = PBXBuildFile; productRef = 82CF86ED2DA7908D00ABC3F4 /* AizomeUIKit */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +29,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				82CF86EB2DA7908D00ABC3F4 /* Aizome in Frameworks */,
+				82CF86EC2DA7908D00ABC3F4 /* AizomeUIKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -71,6 +73,7 @@
 			name = AizomeExample;
 			packageProductDependencies = (
 				82CF86EA2DA7908D00ABC3F4 /* Aizome */,
+				82CF86ED2DA7908D00ABC3F4 /* AizomeUIKit */,
 			);
 			productName = AizomeExample;
 			productReference = 82CF86CF2DA7903F00ABC3F4 /* AizomeExample.app */;
@@ -345,6 +348,10 @@
 		82CF86EA2DA7908D00ABC3F4 /* Aizome */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Aizome;
+		};
+		82CF86ED2DA7908D00ABC3F4 /* AizomeUIKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AizomeUIKit;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Example/AizomeExample/ContentView.swift
+++ b/Example/AizomeExample/ContentView.swift
@@ -51,6 +51,10 @@ struct ContentView: View {
                     "strikethrough": BasicStringStyle(strikethrough: true)
                 ]
             ))
+
+            Divider()
+
+            UIKitInteropView()
         }
         .padding()
     }

--- a/Example/AizomeExample/UIKitInteropView.swift
+++ b/Example/AizomeExample/UIKitInteropView.swift
@@ -1,0 +1,80 @@
+//
+//  UIKitInteropView.swift
+//  AizomeExample
+//
+//  Created by Nobuhiro Ito on 2026/04/10.
+//
+
+import SwiftUI
+import UIKit
+import Aizome
+import AizomeUIKit
+
+private struct UIKitLabel: UIViewRepresentable {
+    let attributedString: AttributedString
+
+    func makeUIView(context: Context) -> UILabel {
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.setContentHuggingPriority(.required, for: .vertical)
+        label.setContentCompressionResistancePriority(.required, for: .vertical)
+        return label
+    }
+
+    func updateUIView(_ uiView: UILabel, context: Context) {
+        uiView.attributedText = NSAttributedString(attributedString)
+    }
+
+    func sizeThatFits(_ proposal: ProposedViewSize, uiView: UILabel, context: Context) -> CGSize? {
+        let width = proposal.width ?? uiView.bounds.width
+        return uiView.sizeThatFits(CGSize(width: width, height: .greatestFiniteMagnitude))
+    }
+}
+
+struct UIKitInteropView: View {
+    private let styles: StringStyleDefinitions = [
+        "bold": InteropBasicStringStyle(
+            swiftUIFont: .system(.body, weight: .bold),
+            uiKitFont: .boldSystemFont(ofSize: 17)
+        ),
+        "red": InteropBasicStringStyle(
+            swiftUIColor: .red,
+            uiKitColor: .red
+        ),
+        "u": InteropBasicStringStyle(underline: true),
+    ]
+
+    var body: some View {
+        let attributed = styledString(
+            "This is <bold><red>bold red</red></bold> and <u>underlined</u> text.",
+            styles: styles,
+            ignoreDefaultStyles: true
+        )
+
+        VStack(alignment: .leading, spacing: 8) {
+            Text("UIKit Interoperability")
+                .font(.title2)
+                .bold()
+
+            Text("Same AttributedString rendered in SwiftUI and UIKit:")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Text("SwiftUI Text")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text(attributed)
+
+            Text("UIKit UILabel")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            UIKitLabel(attributedString: attributed)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
+#Preview {
+    UIKitInteropView()
+        .padding()
+}

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,9 @@ let package = Package(
         .library(
             name: "Aizome",
             targets: ["Aizome"]),
+        .library(
+            name: "AizomeUIKit",
+            targets: ["AizomeUIKit"]),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -20,6 +23,9 @@ let package = Package(
             linkerSettings: [
                 .linkedFramework("SwiftUI")
             ]),
+        .target(
+            name: "AizomeUIKit",
+            dependencies: ["Aizome"]),
         .testTarget(
             name: "AizomeTests",
             dependencies: ["Aizome"]

--- a/Package.swift
+++ b/Package.swift
@@ -30,5 +30,9 @@ let package = Package(
             name: "AizomeTests",
             dependencies: ["Aizome"]
         ),
+        .testTarget(
+            name: "AizomeUIKitTests",
+            dependencies: ["AizomeUIKit"]
+        ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -124,6 +124,51 @@ This approach gives you the flexibility to apply any `AttributeScopes.SwiftUIAtt
 
 Use `AttributeContainerStringStyle` when you want precise control over how your styled segments are rendered.
 
+### UIKit Interoperability
+
+If your app uses both SwiftUI and UIKit, you can use the `AizomeUIKit` library to share styled strings across both frameworks.
+
+First, add `AizomeUIKit` to your target dependencies:
+
+```swift
+.target(
+    name: "<your-target-name>",
+    dependencies: ["Aizome", "AizomeUIKit"]),
+```
+
+`InteropBasicStringStyle` applies attributes to both the SwiftUI and UIKit attribute scopes simultaneously, so a single `AttributedString` can be rendered correctly by both `SwiftUI.Text` and `UIKit.UILabel`.
+
+```swift
+import Aizome
+import AizomeUIKit
+import SwiftUI
+
+let styles: StringStyleDefinitions = [
+    "bold": InteropBasicStringStyle(
+        swiftUIFont: .system(size: 16, weight: .bold),
+        uiKitFont: .boldSystemFont(ofSize: 16)
+    ),
+    "red": InteropBasicStringStyle(
+        swiftUIColor: .red,
+        uiKitColor: .red
+    ),
+]
+
+let attributed = styledString("<bold>Hello</bold>, <red>world</red>!", styles: styles)
+```
+
+Use it directly in SwiftUI:
+
+```swift
+Text(attributed)
+```
+
+Or convert to `NSAttributedString` for UIKit:
+
+```swift
+label.attributedText = NSAttributedString(attributed)
+```
+
 ## Copyright
 
 see ./LICENSE

--- a/Sources/AizomeUIKit/InteropBasicStringStyle.swift
+++ b/Sources/AizomeUIKit/InteropBasicStringStyle.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import SwiftUI
 import UIKit
 import Aizome
@@ -45,3 +46,4 @@ public struct InteropBasicStringStyle: AizomeStringStyle {
         attributed[range].mergeAttributes(container)
     }
 }
+#endif

--- a/Sources/AizomeUIKit/InteropBasicStringStyle.swift
+++ b/Sources/AizomeUIKit/InteropBasicStringStyle.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+import UIKit
+import Aizome
+
+/// A `BasicStringStyle`-equivalent that applies attributes to both SwiftUI and UIKit scopes simultaneously,
+/// allowing a single `AttributedString` to be used in both `SwiftUI.Text` and `UIKit.UILabel`.
+public struct InteropBasicStringStyle: AizomeStringStyle {
+    var swiftUIFont: Font? = nil
+    var uiKitFont: UIFont? = nil
+    var swiftUIColor: Color? = nil
+    var uiKitColor: UIColor? = nil
+    var underline: Bool = false
+    var strikethrough: Bool = false
+
+    public init(
+        swiftUIFont: Font? = nil,
+        uiKitFont: UIFont? = nil,
+        swiftUIColor: Color? = nil,
+        uiKitColor: UIColor? = nil,
+        underline: Bool = false,
+        strikethrough: Bool = false
+    ) {
+        self.swiftUIFont = swiftUIFont
+        self.uiKitFont = uiKitFont
+        self.swiftUIColor = swiftUIColor
+        self.uiKitColor = uiKitColor
+        self.underline = underline
+        self.strikethrough = strikethrough
+    }
+
+    public func apply(to attributed: inout AttributedString, range: Range<AttributedString.Index>) {
+        var container = AttributeContainer()
+        if let swiftUIFont  { container.font = swiftUIFont }
+        if let uiKitFont    { container.uiKit.font = uiKitFont }
+        if let swiftUIColor { container.foregroundColor = swiftUIColor }
+        if let uiKitColor   { container.uiKit.foregroundColor = uiKitColor }
+        if underline {
+            container.underlineStyle = .single
+            container.uiKit.underlineStyle = .single
+        }
+        if strikethrough {
+            container.strikethroughStyle = .single
+            container.uiKit.strikethroughStyle = .single
+        }
+        attributed[range].mergeAttributes(container)
+    }
+}

--- a/Tests/AizomeTests/AizomeTests.swift
+++ b/Tests/AizomeTests/AizomeTests.swift
@@ -1,5 +1,5 @@
 import Testing
-import SwiftUICore
+import SwiftUI
 @testable import Aizome
 
 struct AizomeTests {

--- a/Tests/AizomeTests/AssertStyles.swift
+++ b/Tests/AizomeTests/AssertStyles.swift
@@ -1,6 +1,6 @@
 import Testing
 import Foundation
-import SwiftUICore
+import SwiftUI
 @testable import Aizome
 
 func assertStyle(

--- a/Tests/AizomeTests/ExpectRenderSegment.swift
+++ b/Tests/AizomeTests/ExpectRenderSegment.swift
@@ -1,6 +1,6 @@
 import Testing
 import Foundation
-import SwiftUICore
+import SwiftUI
 @testable import Aizome
 
 enum ExpectRenderSegment {

--- a/Tests/AizomeTests/RenderAsLiteralTests.swift
+++ b/Tests/AizomeTests/RenderAsLiteralTests.swift
@@ -1,5 +1,5 @@
 import Testing
-import SwiftUICore
+import SwiftUI
 import Foundation
 @testable import Aizome
 

--- a/Tests/AizomeTests/RenderWithFormatsTests.swift
+++ b/Tests/AizomeTests/RenderWithFormatsTests.swift
@@ -1,5 +1,5 @@
 import Testing
-import SwiftUICore
+import SwiftUI
 import Foundation
 @testable import Aizome
 

--- a/Tests/AizomeTests/RendererConvertSegmentsTests.swift
+++ b/Tests/AizomeTests/RendererConvertSegmentsTests.swift
@@ -1,5 +1,5 @@
 import Testing
-import SwiftUICore
+import SwiftUI
 import Foundation
 @testable import Aizome
 

--- a/Tests/AizomeUIKitTests/InteropBasicStringStyleTests.swift
+++ b/Tests/AizomeUIKitTests/InteropBasicStringStyleTests.swift
@@ -1,0 +1,135 @@
+#if canImport(UIKit)
+import Testing
+import SwiftUI
+import UIKit
+import Aizome
+@testable import AizomeUIKit
+
+private func swiftUIFont(_ run: AttributedString.Runs.Run) -> Font? {
+    run.font
+}
+
+private func swiftUIColor(_ run: AttributedString.Runs.Run) -> Color? {
+    run.foregroundColor
+}
+
+private func uiKitFont(_ run: AttributedString.Runs.Run) -> UIFont? {
+    run[AttributeScopes.UIKitAttributes.FontAttribute.self]
+}
+
+private func uiKitColor(_ run: AttributedString.Runs.Run) -> UIColor? {
+    run[AttributeScopes.UIKitAttributes.ForegroundColorAttribute.self]
+}
+
+private func uiKitUnderline(_ run: AttributedString.Runs.Run) -> NSUnderlineStyle? {
+    run[AttributeScopes.UIKitAttributes.UnderlineStyleAttribute.self]
+}
+
+private func uiKitStrikethrough(_ run: AttributedString.Runs.Run) -> NSUnderlineStyle? {
+    run[AttributeScopes.UIKitAttributes.StrikethroughStyleAttribute.self]
+}
+
+private func run(of substring: String, in string: AttributedString) throws -> AttributedString.Runs.Run {
+    let range = try #require(string.range(of: substring), "Substring '\(substring)' not found")
+    return try #require(string.runs.first { $0.range == range }, "No run found for substring '\(substring)'")
+}
+
+struct InteropBasicStringStyleTests {
+
+    // MARK: - SwiftUIスコープ
+
+    @MainActor @Test func swiftUIScope_color() throws {
+        let result = styledString(
+            "<red>Hello</red>",
+            styles: ["red": InteropBasicStringStyle(swiftUIColor: .red)],
+            ignoreDefaultStyles: true
+        )
+        let r = try run(of: "Hello", in: result)
+        #expect(swiftUIColor(r) == .red)
+    }
+
+    @MainActor @Test func swiftUIScope_font() throws {
+        let font = Font.system(size: 12, weight: .bold)
+        let result = styledString(
+            "<bold>Hello</bold>",
+            styles: ["bold": InteropBasicStringStyle(swiftUIFont: font)],
+            ignoreDefaultStyles: true
+        )
+        let r = try run(of: "Hello", in: result)
+        #expect(swiftUIFont(r) == font)
+    }
+
+    // MARK: - UIKitスコープ
+
+    @MainActor @Test func uiKitScope_color() throws {
+        let result = styledString(
+            "<red>Hello</red>",
+            styles: ["red": InteropBasicStringStyle(uiKitColor: .red)],
+            ignoreDefaultStyles: true
+        )
+        let r = try run(of: "Hello", in: result)
+        #expect(uiKitColor(r) == .red)
+    }
+
+    @MainActor @Test func uiKitScope_font() throws {
+        let font = UIFont.boldSystemFont(ofSize: 12)
+        let result = styledString(
+            "<bold>Hello</bold>",
+            styles: ["bold": InteropBasicStringStyle(uiKitFont: font)],
+            ignoreDefaultStyles: true
+        )
+        let r = try run(of: "Hello", in: result)
+        #expect(uiKitFont(r) == font)
+    }
+
+    // MARK: - 両スコープの同居
+
+    @MainActor @Test func bothScopes_colorCoexist() throws {
+        let result = styledString(
+            "<c>Hello</c>",
+            styles: ["c": InteropBasicStringStyle(swiftUIColor: .blue, uiKitColor: .green)],
+            ignoreDefaultStyles: true
+        )
+        let r = try run(of: "Hello", in: result)
+        #expect(swiftUIColor(r) == .blue)
+        #expect(uiKitColor(r) == .green)
+    }
+
+    @MainActor @Test func bothScopes_fontCoexist() throws {
+        let swiftFont = Font.system(size: 12, weight: .bold)
+        let uiFont = UIFont.boldSystemFont(ofSize: 14)
+        let result = styledString(
+            "<f>Hello</f>",
+            styles: ["f": InteropBasicStringStyle(swiftUIFont: swiftFont, uiKitFont: uiFont)],
+            ignoreDefaultStyles: true
+        )
+        let r = try run(of: "Hello", in: result)
+        #expect(swiftUIFont(r) == swiftFont)
+        #expect(uiKitFont(r) == uiFont)
+    }
+
+    // MARK: - underline / strikethrough
+
+    @MainActor @Test func underline_bothScopes() throws {
+        let result = styledString(
+            "<u>Hello</u>",
+            styles: ["u": InteropBasicStringStyle(underline: true)],
+            ignoreDefaultStyles: true
+        )
+        let r = try run(of: "Hello", in: result)
+        #expect(r.underlineStyle == .single)
+        #expect(uiKitUnderline(r) == .single)
+    }
+
+    @MainActor @Test func strikethrough_bothScopes() throws {
+        let result = styledString(
+            "<s>Hello</s>",
+            styles: ["s": InteropBasicStringStyle(strikethrough: true)],
+            ignoreDefaultStyles: true
+        )
+        let r = try run(of: "Hello", in: result)
+        #expect(r.strikethroughStyle == .single)
+        #expect(uiKitStrikethrough(r) == .single)
+    }
+}
+#endif


### PR DESCRIPTION
- AttributeContainerは、1つのインスタンスにSwiftUI向けの定義とUIKit向けの定義を両方定義することができる
- UIKitとの相互運用のために `InteropBasicStringStyle` をAizomeUIKitとして提供する。